### PR TITLE
Fix private workflows: Add automatic Docker tag generation

### DIFF
--- a/.github/workflows/private-build-compiled-mastodon.yml
+++ b/.github/workflows/private-build-compiled-mastodon.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v4
 
+      - name: Generate version tag
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.docker_image_version }}" ]; then
+            echo "tag=${{ github.event.inputs.docker_image_version }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$(date +%Y%m%d)-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -49,7 +58,7 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-compiled:${{ github.event.inputs.docker_image_version || 'latest' }}
+          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-compiled:${{ steps.version.outputs.tag }}
           secrets: |
             "ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY }}"
             "ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT }}"

--- a/.github/workflows/private-build-compiled-mastodon.yml
+++ b/.github/workflows/private-build-compiled-mastodon.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-compiled:${{ github.event.inputs.docker_image_version }}
+          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-compiled:${{ github.event.inputs.docker_image_version || 'latest' }}
           secrets: |
             "ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY }}"
             "ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT }}"

--- a/.github/workflows/private-streaming-compiled.yml
+++ b/.github/workflows/private-streaming-compiled.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v4
 
+      - name: Generate version tag
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.docker_image_version }}" ]; then
+            echo "tag=${{ github.event.inputs.docker_image_version }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$(date +%Y%m%d)-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -49,7 +58,7 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-streaming-compiled:${{ github.event.inputs.docker_image_version || 'latest' }}
+          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-streaming-compiled:${{ steps.version.outputs.tag }}
           secrets: |
             "ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY }}"
             "ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT }}"

--- a/.github/workflows/private-streaming-compiled.yml
+++ b/.github/workflows/private-streaming-compiled.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-streaming-compiled:${{ github.event.inputs.docker_image_version }}
+          tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-streaming-compiled:${{ github.event.inputs.docker_image_version || 'latest' }}
           secrets: |
             "ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY }}"
             "ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=${{ secrets.ARG_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT }}"


### PR DESCRIPTION
## Summary
Fixes private workflow Docker builds by adding automatic tag generation for push events.

## Changes
- Add `Generate version tag` step to both private workflows
- Use `YYYYMMDD-{short-hash}` format for automatic tags (e.g., `20250930-abc1234`)
- Manual `workflow_dispatch` can still provide custom version via input

## Test plan
- [x] Workflow builds triggered on push to forked-main
- [ ] Verify Docker images are tagged correctly
- [ ] Verify manual dispatch still works with custom version

🤖 Generated with [Claude Code](https://claude.com/claude-code)