### PR TITLE
Fix CDN_HOST support in Vite configuration

### DIFF
--- a/.github/workflows/private-build-compiled-mastodon.yml
+++ b/.github/workflows/private-build-compiled-mastodon.yml
@@ -59,6 +59,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USER_NAME }}/mastodon-compiled:${{ steps.version.outputs.tag }}
+          build-args: |
+            CDN_HOST=${{ vars.CDN_HOST }}
           secrets: |
             "ARG_SECRET_KEY_BASE=${{ secrets.ARG_SECRET_KEY_BASE }}"
             "ARG_OTP_SECRET=${{ secrets.ARG_OTP_SECRET }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -398,8 +398,10 @@ RUN \
 COPY . /opt/mastodon/
 
 # Copy compiled assets to layer
-COPY --from=precompiler /opt/mastodon/public/packs /opt/mastodon/public/packs
-COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
+# COPY --from=precompiler /opt/mastodon/public/packs /opt/mastodon/public/packs
+# COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
+COPY --from=precompiler /opt/mastodon/public /opt/mastodon/public
+
 # Copy bundler components to layer
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
 # Copy libvips components to layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ ARG MASTODON_VERSION_PRERELEASE=""
 ARG MASTODON_VERSION_METADATA=""
 # Will be available as Mastodon::Version.source_commit
 ARG SOURCE_COMMIT=""
+# CDN host URL for Vite asset compilation (no trailing slash)
+# Example: https://mastodon-static.theatl.social
+ARG CDN_HOST=""
 
 # Allow Ruby on Rails to serve static files
 # See: https://docs.joinmastodon.org/admin/config/#rails_serve_static_files
@@ -284,6 +287,7 @@ RUN \
 FROM build AS precompiler
 
 ARG TARGETPLATFORM
+ARG CDN_HOST
 
 # Copy Mastodon sources into layer
 COPY . /opt/mastodon/
@@ -331,6 +335,8 @@ RUN \
   export ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=$(cat /run/secrets/ARG_ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY 2>/dev/null || echo ""); \
   # Use dummy key if no secrets provided (for local builds without secrets)
   if [ -z "$SECRET_KEY_BASE" ]; then export SECRET_KEY_BASE_DUMMY=1; fi; \
+  # Export CDN_HOST for Vite asset compilation (if provided)
+  if [ -n "$CDN_HOST" ]; then export CDN_HOST="$CDN_HOST"; fi; \
   # Use Ruby on Rails to create Mastodon assets
   bundle exec rails assets:precompile; \
   # Cleanup temporary files

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -39,9 +39,14 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
   }
   const outDir = path.resolve('public', outDirName);
 
+  // Use CDN_HOST for production builds if configured
+  const cdnHost = process.env.CDN_HOST;
+  const base =
+    isProdBuild && cdnHost ? `${cdnHost}/${outDirName}/` : `/${outDirName}/`;
+
   return {
     root: jsRoot,
-    base: `/${outDirName}/`,
+    base,
     envDir: __dirname,
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary

Fixes CDN_HOST environment variable not being respected after upgrading to Mastodon v4.5+, which switched from Webpack to Vite.

## Problem

After the v4.5+ upgrade, all Vite-generated assets (JavaScript chunks, emoji data files, CSS) were being loaded from the local domain instead of the configured CDN at `mastodon-static.theatl.social`.

**Root Cause:** Vite's `base` path was hardcoded to `/${outDirName}/` in vite.config.mts. Since Vite generates asset URLs at build time (via `import.meta.glob()` and code splitting), these URLs don't respect Rails' runtime `config.asset_host` setting.

## Solution

Configure Vite's `base` option to use `CDN_HOST` during production builds:

```typescript
const cdnHost = process.env.CDN_HOST;
const base = isProdBuild && cdnHost ? `${cdnHost}/${outDirName}/` : `/${outDirName}/`;
```

## Affected Assets

This fix ensures the following assets correctly use the CDN:
- JavaScript chunks (e.g., `schedule_idle_task-*.js`)
- Emoji data files (e.g., `compact-*.json`)
- CSS files and other Vite-managed assets

## Build Requirements

**Important:** `CDN_HOST` must be set as an environment variable **during the production build**, not just at runtime:

```bash
export CDN_HOST=https://mastodon-static.theatl.social  # No trailing slash
yarn build:production
```

Or in Dockerfile:
```dockerfile
ENV CDN_HOST=https://mastodon-static.theatl.social
RUN yarn build:production
```

## Testing

After merging and rebuilding with `CDN_HOST` set:
1. Check browser network tab for asset requests
2. Verify URLs like `/packs/assets/compact-*.json` become `https://mastodon-static.theatl.social/packs/assets/compact-*.json`
3. Confirm dynamically imported JS chunks use CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)