### PR TITLE
Add environment variable to block API registrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ bundle-platform:
 
 # Linting targets using Docker (no local Ruby/Node installation required)
 
-# Ruby linting with Rubocop
+# Ruby linting with Rubocop (versions pinned to match Gemfile.lock)
 rubocop:
 	@echo "Running Rubocop via Docker (Ruby $(RUBY_VERSION))..."
 	docker run --rm --platform linux/amd64 -v $$(pwd):/app -w /app ruby:$(RUBY_VERSION)-slim-trixie sh -c \
 	  "apt-get update -qq && apt-get install -y -qq build-essential git > /dev/null 2>&1 && \
-	   gem install --silent rubocop rubocop-rails rubocop-rspec rubocop-rspec_rails rubocop-capybara rubocop-performance rubocop-i18n && \
+	   gem install --silent rubocop:1.81.7 rubocop-rails:2.33.4 rubocop-rspec:3.7.0 rubocop-rspec_rails:2.31.0 rubocop-capybara:2.22.1 rubocop-performance:1.26.1 rubocop-i18n:3.2.3 && \
 	   rubocop"
 
 lint-ruby: rubocop

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -132,7 +132,7 @@ class Api::V1::AccountsController < Api::BaseController
       render json: {
         error: 'API registrations are disabled',
         error_description: 'Please sign up via our website instead',
-        signup_url: web_signup_url
+        signup_url: web_signup_url,
       }, status: 403
       return
     end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -128,6 +128,23 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def check_enabled_registrations
+    if api_registrations_disabled?
+      render json: {
+        error: 'API registrations are disabled',
+        error_description: 'Please sign up via our website instead',
+        signup_url: web_signup_url
+      }, status: 403
+      return
+    end
+
     forbidden unless allowed_registration?(request.remote_ip, invite)
+  end
+
+  def api_registrations_disabled?
+    ENV['DISABLE_API_REGISTRATIONS'] == 'true'
+  end
+
+  def web_signup_url
+    ENV['WEB_SIGNUP_URL'].presence || new_user_registration_url
   end
 end

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -183,6 +183,56 @@ RSpec.describe '/api/v1/accounts' do
           .to start_with('application/json')
       end
     end
+
+    context 'when API registrations are disabled' do
+      let(:agreement) { 'true' }
+
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('DISABLE_API_REGISTRATIONS').and_return('true')
+      end
+
+      it 'returns http forbidden with error message', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body[:error]).to eq('API registrations are disabled')
+        expect(response.parsed_body[:error_description]).to eq('Please sign up via our website instead')
+        expect(response.parsed_body[:signup_url]).to be_present
+      end
+
+      it 'does not create a user' do
+        expect { subject }
+          .to not_change(User, :count)
+          .and not_change(Account, :count)
+      end
+
+      context 'when WEB_SIGNUP_URL is set' do
+        before do
+          allow(ENV).to receive(:[]).with('WEB_SIGNUP_URL').and_return('https://example.com/custom-signup')
+        end
+
+        it 'returns the custom signup URL' do
+          subject
+
+          expect(response.parsed_body[:signup_url]).to eq('https://example.com/custom-signup')
+        end
+      end
+
+      context 'when WEB_SIGNUP_URL is not set' do
+        before do
+          allow(ENV).to receive(:[]).with('WEB_SIGNUP_URL').and_return(nil)
+        end
+
+        it 'returns the default signup URL' do
+          subject
+
+          expect(response.parsed_body[:signup_url]).to match(%r{/auth/sign_up})
+        end
+      end
+    end
   end
 
   describe 'POST /api/v1/accounts/:id/follow' do


### PR DESCRIPTION
## Summary

- Adds `DISABLE_API_REGISTRATIONS` environment variable to block mobile app signup attempts
- Returns 403 error with custom message directing users to web signup page
- Adds `WEB_SIGNUP_URL` environment variable for custom signup URL (optional)
- Web-based signups continue to work normally
- Includes comprehensive test coverage

## Motivation

Allows server administrators to control where users can sign up, directing mobile app users to the web interface for registration while maintaining flexibility in how registrations are handled.

## Implementation Details

- Modified `Api::V1::AccountsController#check_enabled_registrations` to check for `DISABLE_API_REGISTRATIONS` env var
- API returns 403 with JSON error response including:
  - `error`: "API registrations are disabled"
  - `error_description`: "Please sign up via our website instead"
  - `signup_url`: Custom URL from `WEB_SIGNUP_URL` or default `/auth/sign_up`
- Web registrations via `Auth::RegistrationsController` unaffected

## Test Plan

- [x] Added 4 test cases in `spec/requests/api/v1/accounts_spec.rb`
- [x] Test blocking behavior returns 403
- [x] Test no user creation when blocked
- [x] Test custom signup URL handling
- [x] Test default signup URL fallback
- [ ] Manual testing: Set env vars and attempt API signup via mobile app
- [ ] Verify web signups still work

## Configuration

Add to `.env.production`:

\`\`\`bash
# Block API-based signups (mobile apps)
DISABLE_API_REGISTRATIONS=true

# Optional: Custom signup URL
WEB_SIGNUP_URL=https://theconnector.social/auth/sign_up
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)