### PR TITLE
Merge upstream v4.5.6 + fix member-site registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.5.6] - 2026-02-03
+
+### Security
+
+- Fix ActivityPub collection caching logic for pinned posts and featured tags not checking blocked accounts ([GHSA-ccpr-m53r-mfwr](https://github.com/mastodon/mastodon/security/advisories/GHSA-ccpr-m53r-mfwr))
+
+### Changed
+
+- Shorten caching of quote posts pending approval (#37570 and #37592 by @ClearlyClaire)
+
+### Fixed
+
+- Fix relationship cache not being cleared when handling account migrations (#37664 by @ClearlyClaire)
+- Fix quote cancel button not appearing after edit then delete-and-redraft (#37066 by @PGrayCS)
+- Fix followers with profile subscription (bell icon) being notified of post edits (#37646 by @ClearlyClaire)
+- Fix error when encountering invalid tag in updated object (#37635 by @ClearlyClaire)
+- Fix cross-server conversation tracking (#37559 by @ClearlyClaire)
+- Fix recycled connections not being immediately closed (#37335 and #37674 by @ClearlyClaire and @shleeable)
+
 ## [4.5.5] - 2026-01-20
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.5.5] - 2026-01-20
+
+### Security
+
+- Fix missing limits on various federated properties [GHSA-gg8q-rcg7-p79g](https://github.com/mastodon/mastodon/security/advisories/GHSA-gg8q-rcg7-p79g)
+- Fix remote user suspension bypass [GHSA-5h2f-wg8j-xqwp](https://github.com/mastodon/mastodon/security/advisories/GHSA-5h2f-wg8j-xqwp)
+- Fix missing length limits on some user-provided fields [GHSA-6x3w-9g92-gvf3](https://github.com/mastodon/mastodon/security/advisories/GHSA-6x3w-9g92-gvf3)
+- Fix missing access check for push notification settings update [GHSA-f3q8-7vw3-69v4](https://github.com/mastodon/mastodon/security/advisories/GHSA-f3q8-7vw3-69v4)
+
+### Changed
+
+- Skip tombstone creation on deleting from 404 (#37533 by @ClearlyClaire)
+
+### Fixed
+
+- Fix potential duplicate handling of quote accept/reject/delete (#37537 by @ClearlyClaire)
+- Fix `FeedManager#filter_from_home` error when handling a reblog of a deleted status (#37486 by @ClearlyClaire)
+- Fix needlessly complicated SQL query in status batch removal (#37469 by @ClearlyClaire)
+- Fix `quote_approval_policy` being reset to user defaults when omitted in status update (#37436 and #37474 by @mjankowski and @shleeable)
+- Fix `Vary` parsing in cache control enforcement (#37426 by @MegaManSec)
+- Fix missing URI scheme test in `QuoteRequest` handling (#37425 by @MegaManSec)
+- Fix thread-unsafe ActivityPub activity dispatch (#37423 by @MegaManSec)
+- Fix URI generation for reblogs by accounts with numerical ActivityPub identifiers (#37415 by @oneiros)
+- Fix SignatureParser accepting duplicate parameters in HTTP Signature header (#37375 by @shleeable)
+- Fix emoji with variant selector not being rendered properly (#37320 by @ChaosExAnima)
+- Fix mobile admin sidebar displaying under batch table toolbar (#37307 by @diondiondion)
+
 ## [4.5.4] - 2026-01-07
 
 ### Security

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,42 @@
+# Lightweight dev/lint container for Ruby tooling (rubocop, haml-lint, etc.)
+# This ensures consistent Ruby + bundler versions across all developer machines.
+#
+# Build:  docker build -f Dockerfile.dev -t theconnector-dev .
+# Usage:  docker run --rm -v "$PWD:/app" -w /app theconnector-dev bin/rubocop -a <files>
+
+ARG RUBY_VERSION="3.4.8"
+
+FROM ruby:${RUBY_VERSION}-slim-bookworm
+
+# Install native extension build dependencies needed by development gems
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+      libicu-dev \
+      libidn-dev \
+      libpq-dev \
+      libssl-dev \
+      libyaml-dev \
+      libgdbm-dev \
+      libgmp-dev \
+      zlib1g-dev \
+      pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the exact bundler version the project uses
+RUN gem install bundler -v '~> 2.7'
+
+WORKDIR /app
+
+# Copy dependency files first (Docker layer caching)
+COPY Gemfile Gemfile.lock .ruby-version ./
+
+# Install only default + development gems (rubocop, haml-lint, etc.)
+# Skip test group to avoid pulling in capybara/playwright native deps
+RUN bundle config set --local without 'test' && \
+    bundle install --jobs "$(nproc)"
+
+# Default entrypoint: run any command in the project context
+ENTRYPOINT ["bundle", "exec"]
+CMD ["rubocop", "--version"]

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -48,3 +48,22 @@ Mastodon requires all `POST` requests to be signed, and MAY require `GET` reques
 ### Additional documentation
 
 - [Mastodon documentation](https://docs.joinmastodon.org/)
+
+## Size limits
+
+Mastodon imposes a few hard limits on federated content.
+These limits are intended to be very generous and way above what the Mastodon user experience is optimized for, so as to accomodate future changes and unusual or unforeseen usage patterns, while still providing some limits for performance reasons.
+The following table attempts to summary those limits.
+
+| Limited property                                              | Size limit | Consequence of exceeding the limit |
+| ------------------------------------------------------------- | ---------- | ---------------------------------- |
+| Serialized JSON-LD                                            | 1MB        | **Activity is rejected/dropped**   |
+| Profile fields (actor `PropertyValue` attachments) name/value | 2047       | Field name/value is truncated      |
+| Number of profile fields (actor `PropertyValue` attachments)  | 50         | Fields list is truncated           |
+| Poll options (number of `anyOf`/`oneOf` in a `Question`)      | 500        | Items list is truncated            |
+| Account username (actor `preferredUsername`) length           | 2048       | **Actor will be rejected**         |
+| Account display name (actor `name`) length                    | 2048       | Display name will be truncated     |
+| Account note (actor `summary`) length                         | 20kB       | Account note will be truncated     |
+| Account `attributionDomains`                                  | 256        | List will be truncated             |
+| Account aliases (actor `alsoKnownAs`)                         | 256        | List will be truncated             |
+| Custom emoji shortcode (`Emoji` `name`)                       | 2048       | Emoji will be rejected             |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,5 +18,4 @@ A "vulnerability in Mastodon" is a vulnerability in the code distributed through
 | 4.5.x   | Yes              |
 | 4.4.x   | Yes              |
 | 4.3.x   | Until 2026-05-06 |
-| 4.2.x   | Until 2026-01-08 |
-| < 4.2   | No               |
+| < 4.3   | No               |

--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -3,6 +3,7 @@
 class ActivityPub::InboxesController < ActivityPub::BaseController
   include JsonLdHelper
 
+  before_action :skip_large_payload
   before_action :skip_unknown_actor_activity
   before_action :require_actor_signature!
   skip_before_action :authenticate_user!
@@ -15,6 +16,10 @@ class ActivityPub::InboxesController < ActivityPub::BaseController
   end
 
   private
+
+  def skip_large_payload
+    head 413 if request.content_length > ActivityPub::Activity::MAX_JSON_SIZE
+  end
 
   def skip_unknown_actor_activity
     head 202 if unknown_affected_account?

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -128,6 +128,8 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def check_enabled_registrations
+    return if trusted_registration_app?
+
     if api_registrations_disabled?
       render json: {
         error: 'API registrations are disabled',
@@ -146,5 +148,12 @@ class Api::V1::AccountsController < Api::BaseController
 
   def web_signup_url
     ENV['WEB_SIGNUP_URL'].presence || new_user_registration_url
+  end
+
+  def trusted_registration_app?
+    trusted_ids = ENV['TRUSTED_REGISTRATION_CLIENT_IDS']&.split(',')&.map(&:strip)
+    return false if trusted_ids.blank?
+
+    doorkeeper_token&.application&.uid.in?(trusted_ids)
   end
 end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def create
-    token    = AppSignUpService.new.call(doorkeeper_token.application, request.remote_ip, account_params)
+    token    = AppSignUpService.new.call(doorkeeper_token.application, request.remote_ip, account_params, trusted: trusted_registration_app?)
     response = Doorkeeper::OAuth::TokenResponse.new(token)
 
     headers.merge!(response.headers)

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -106,9 +106,7 @@ class Api::V1::StatusesController < Api::BaseController
     @status = Status.where(account: current_account).find(params[:id])
     authorize @status, :update?
 
-    UpdateStatusService.new.call(
-      @status,
-      current_account.id,
+    update_options = {
       text: status_params[:status],
       media_ids: status_params[:media_ids],
       media_attributes: status_params[:media_attributes],
@@ -116,8 +114,11 @@ class Api::V1::StatusesController < Api::BaseController
       language: status_params[:language],
       spoiler_text: status_params[:spoiler_text],
       poll: status_params[:poll],
-      quote_approval_policy: quote_approval_policy
-    )
+    }
+
+    update_options[:quote_approval_policy] = quote_approval_policy if status_params[:quote_approval_policy].present?
+
+    UpdateStatusService.new.call(@status, current_account.id, update_options)
 
     render json: @status, serializer: REST::StatusSerializer
   end

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -62,7 +62,7 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   end
 
   def set_push_subscription
-    @push_subscription = ::Web::PushSubscription.find(params[:id])
+    @push_subscription = ::Web::PushSubscription.where(user_id: active_session.user_id).find(params[:id])
   end
 
   def subscription_params

--- a/app/controllers/concerns/cache_concern.rb
+++ b/app/controllers/concerns/cache_concern.rb
@@ -19,7 +19,7 @@ module CacheConcern
   # from being used as cache keys, while allowing to `Vary` on them (to not serve
   # anonymous cached data to authenticated requests when authentication matters)
   def enforce_cache_control!
-    vary = response.headers['Vary']&.split&.map { |x| x.strip.downcase }
+    vary = response.headers['Vary'].to_s.split(',').map { |x| x.strip.downcase }.reject(&:empty?)
     return unless vary.present? && %w(cookie authorization signature).any? { |header| vary.include?(header) && request.headers[header].present? }
 
     response.cache_control.replace(private: true, no_store: true)

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -29,7 +29,7 @@ class StatusesController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: true if @status.distributable? && public_fetch_mode?
+        expires_in @status.quote&.pending? ? 5.seconds : 3.minutes, public: true if @status.distributable? && public_fetch_mode?
         render_with_cache json: @status, content_type: 'application/activity+json', serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter
       end
     end

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -145,6 +145,7 @@ class Status extends ImmutablePureComponent {
     'hidden',
     'unread',
     'pictureInPicture',
+    'onQuoteCancel',
   ];
 
   state = {

--- a/app/javascript/mastodon/features/emoji/normalize.test.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.test.ts
@@ -33,6 +33,7 @@ describe('emojiToUnicodeHex', () => {
     ['⚫', '26AB'],
     ['🖤', '1F5A4'],
     ['💀', '1F480'],
+    ['❤️', '2764'], // Checks for trailing variation selector removal.
     ['💂‍♂️', '1F482-200D-2642-FE0F'],
   ] as const)(
     'emojiToUnicodeHex converts %s to %s',

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -30,6 +30,12 @@ export function emojiToUnicodeHex(emoji: string): string {
       codes.push(code);
     }
   }
+
+  // Handles how Emojibase removes the variation selector for single code emojis.
+  // See: https://emojibase.dev/docs/spec/#merged-variation-selectors
+  if (codes.at(1) === VARIATION_SELECTOR_CODE && codes.length === 2) {
+    codes.pop();
+  }
   return hexNumbersToString(codes);
 }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -163,6 +163,7 @@ $content-width: 840px;
     width: 100%;
     max-width: $content-width;
     flex: 1 1 auto;
+    isolation: isolate;
   }
 
   @media screen and (max-width: ($content-width + $sidebar-width)) {

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -5,6 +5,7 @@ class ActivityPub::Activity
   include Redisable
   include Lockable
 
+  MAX_JSON_SIZE = 1.megabyte
   SUPPORTED_TYPES = %w(Note Question).freeze
   CONVERTED_TYPES = %w(Image Audio Video Article Page Event).freeze
 

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -21,14 +21,13 @@ class ActivityPub::Activity
 
   class << self
     def factory(json, account, **)
-      @json = json
-      klass&.new(json, account, **)
+      klass_for(json)&.new(json, account, **)
     end
 
     private
 
-    def klass
-      case @json['type']
+    def klass_for(json)
+      case json['type']
       when 'Create'
         ActivityPub::Activity::Create
       when 'Announce'

--- a/app/lib/activitypub/activity/accept.rb
+++ b/app/lib/activitypub/activity/accept.rb
@@ -46,7 +46,7 @@ class ActivityPub::Activity::Accept < ActivityPub::Activity
 
   def accept_quote!(quote)
     approval_uri = value_or_id(first_of_value(@json['result']))
-    return if unsupported_uri_scheme?(approval_uri) || quote.quoted_account != @account || !quote.status.local?
+    return if unsupported_uri_scheme?(approval_uri) || quote.quoted_account != @account || !quote.status.local? || !quote.pending?
 
     # NOTE: we are not going through `ActivityPub::VerifyQuoteService` as the `Accept` is as authoritative
     # as the stamp, but this means we are not checking the stamp, which may lead to inconsistencies

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -379,6 +379,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def conversation_from_uri(uri)
     return nil if uri.nil?
     return Conversation.find_by(id: OStatus::TagManager.instance.unique_tag_to_local_id(uri, 'Conversation')) if OStatus::TagManager.instance.local_id?(uri)
+    return ActivityPub::TagManager.instance.uri_to_resource(uri, Conversation) if ActivityPub::TagManager.instance.local_uri?(uri)
 
     begin
       Conversation.find_or_create_by!(uri: uri)

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -56,7 +56,7 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   end
 
   def revoke_quote
-    @quote = Quote.find_by(approval_uri: object_uri, quoted_account: @account)
+    @quote = Quote.find_by(approval_uri: object_uri, quoted_account: @account, state: [:pending, :accepted])
     return if @quote.nil?
 
     ActivityPub::Forwarder.new(@account, @json, @quote.status).forward! if @quote.status.present?

--- a/app/lib/activitypub/activity/quote_request.rb
+++ b/app/lib/activitypub/activity/quote_request.rb
@@ -47,7 +47,7 @@ class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
     # NOTE: Replacing the object's context by that of the parent activity is
     # not sound, but it's consistent with the rest of the codebase
     instrument = @json['instrument'].merge({ '@context' => @json['@context'] })
-    return if non_matching_uri_hosts?(instrument['id'], @account.uri)
+    return if non_matching_uri_hosts?(@account.uri, instrument['id'])
 
     ActivityPub::FetchRemoteStatusService.new.call(instrument['id'], prefetched_body: instrument, on_behalf_of: quoted_status.account, request_id: @options[:request_id])
   end

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -30,7 +30,8 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
     @status = Status.find_by(uri: object_uri, account_id: @account.id)
 
     # Ignore updates for old unknown objects, since those are updates we are not interested in
-    return if @status.nil? && object_too_old?
+    # Also ignore unknown objects from suspended users for the same reasons
+    return if @status.nil? && (@account.suspended? || object_too_old?)
 
     # We may be getting `Create` and `Update` out of order
     @status ||= ActivityPub::Activity::Create.new(@json, @account, **@options).perform

--- a/app/lib/activitypub/parser/poll_parser.rb
+++ b/app/lib/activitypub/parser/poll_parser.rb
@@ -3,6 +3,10 @@
 class ActivityPub::Parser::PollParser
   include JsonLdHelper
 
+  # Limit the number of items for performance purposes.
+  # We truncate rather than error out to avoid missing the post entirely.
+  MAX_ITEMS = 500
+
   def initialize(json)
     @json = json
   end
@@ -48,6 +52,6 @@ class ActivityPub::Parser::PollParser
   private
 
   def items
-    @json['anyOf'] || @json['oneOf']
+    (@json['anyOf'] || @json['oneOf'])&.take(MAX_ITEMS)
   end
 end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -50,7 +50,7 @@ class ActivityPub::TagManager
       context_url(target) unless target.parent_account_id.nil? || target.parent_status_id.nil?
     when :note, :comment, :activity
       if target.account.numeric_ap_id?
-        return activity_ap_account_status_url(target.account, target) if target.reblog?
+        return activity_ap_account_status_url(target.account.id, target) if target.reblog?
 
         ap_account_status_url(target.account.id, target)
       else

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -241,12 +241,6 @@ class ActivityPub::TagManager
     !host.nil? && (::TagManager.instance.local_domain?(host) || ::TagManager.instance.web_domain?(host))
   end
 
-  def uri_to_local_id(uri, param = :id)
-    path_params = Rails.application.routes.recognize_path(uri)
-    path_params[:username] = Rails.configuration.x.local_domain if path_params[:controller] == 'instance_actors'
-    path_params[param]
-  end
-
   def uris_to_local_accounts(uris)
     usernames = []
     ids = []
@@ -264,6 +258,14 @@ class ActivityPub::TagManager
     uri_to_resource(uri, Account)
   end
 
+  def uri_to_local_conversation(uri)
+    path_params = Rails.application.routes.recognize_path(uri)
+    return unless path_params[:controller] == 'activitypub/contexts'
+
+    account_id, conversation_id = path_params[:id].split('-')
+    Conversation.find_by(parent_account_id: account_id, id: conversation_id)
+  end
+
   def uri_to_resource(uri, klass)
     return if uri.nil?
 
@@ -271,6 +273,8 @@ class ActivityPub::TagManager
       case klass.name
       when 'Account'
         uris_to_local_accounts([uri]).first
+      when 'Conversation'
+        uri_to_local_conversation(uri)
       else
         StatusFinder.new(uri).status
       end

--- a/app/lib/connection_pool/shared_timed_stack.rb
+++ b/app/lib/connection_pool/shared_timed_stack.rb
@@ -71,6 +71,7 @@ class ConnectionPool::SharedTimedStack
       throw_away_connection = @queue.pop
       @tagged_queue[throw_away_connection.site].delete(throw_away_connection)
       @create_block.call(preferred_tag)
+      throw_away_connection.close
     elsif @created != @max
       connection = @create_block.call(preferred_tag)
       @created += 1

--- a/app/lib/connection_pool/shared_timed_stack.rb
+++ b/app/lib/connection_pool/shared_timed_stack.rb
@@ -70,8 +70,8 @@ class ConnectionPool::SharedTimedStack
     if @created == @max && !@queue.empty?
       throw_away_connection = @queue.pop
       @tagged_queue[throw_away_connection.site].delete(throw_away_connection)
-      @create_block.call(preferred_tag)
       throw_away_connection.close
+      @create_block.call(preferred_tag)
     elsif @created != @max
       connection = @create_block.call(preferred_tag)
       @created += 1

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -450,6 +450,7 @@ class FeedManager
     return :filter    if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
     return :skip_home if timeline_type != :list && crutches[:exclusive_list_users][status.account_id].present?
     return :filter    if crutches[:languages][status.account_id].present? && status.language.present? && !crutches[:languages][status.account_id].include?(status.language)
+    return :filter    if status.reblog? && status.reblog.blank?
 
     check_for_blocks = crutches[:active_mentions][status.id] || []
     check_for_blocks.push(status.account_id)

--- a/app/lib/ostatus/tag_manager.rb
+++ b/app/lib/ostatus/tag_manager.rb
@@ -11,16 +11,12 @@ class OStatus::TagManager
   def unique_tag_to_local_id(tag, expected_type)
     return nil unless local_id?(tag)
 
-    if ActivityPub::TagManager.instance.local_uri?(tag)
-      ActivityPub::TagManager.instance.uri_to_local_id(tag)
-    else
-      matches = Regexp.new("objectId=([\\d]+):objectType=#{expected_type}").match(tag)
-      matches[1] unless matches.nil?
-    end
+    matches = Regexp.new("objectId=([\\d]+):objectType=#{expected_type}").match(tag)
+    matches[1] unless matches.nil?
   end
 
   def local_id?(id)
-    id.start_with?("tag:#{Rails.configuration.x.local_domain}") || ActivityPub::TagManager.instance.local_uri?(id)
+    id.start_with?("tag:#{Rails.configuration.x.local_domain}")
   end
 
   def uri_for(target)

--- a/app/lib/signature_parser.rb
+++ b/app/lib/signature_parser.rb
@@ -25,9 +25,13 @@ class SignatureParser
 
     # Use `skip` instead of `scan` as we only care about the subgroups
     while scanner.skip(PARAM_RE)
+      key = scanner[:key]
+      # Detect a duplicate key
+      raise Mastodon::SignatureVerificationError, 'Error parsing signature with duplicate keys' if params.key?(key)
+
       # This is not actually correct with regards to quoted pairs, but it's consistent
       # with our previous implementation, and good enough in practice.
-      params[scanner[:key]] = scanner[:value] || scanner[:quoted_value][1...-1]
+      params[key] = scanner[:value] || scanner[:quoted_value][1...-1]
 
       scanner.skip(/\s*/)
       return params if scanner.eos?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -80,6 +80,13 @@ class Account < ApplicationRecord
   DISPLAY_NAME_LENGTH_LIMIT = 30
   NOTE_LENGTH_LIMIT = 500
 
+  # Hard limits for federated content
+  USERNAME_LENGTH_HARD_LIMIT = 2048
+  DISPLAY_NAME_LENGTH_HARD_LIMIT = 2048
+  NOTE_LENGTH_HARD_LIMIT = 20.kilobytes
+  ATTRIBUTION_DOMAINS_HARD_LIMIT = 256
+  ALSO_KNOWN_AS_HARD_LIMIT = 256
+
   AUTOMATED_ACTOR_TYPES = %w(Application Service).freeze
 
   include Attachmentable # Load prior to Avatar & Header concerns
@@ -112,7 +119,7 @@ class Account < ApplicationRecord
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
 
   # Remote user validations, also applies to internal actors
-  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (remote? || actor_type_application?) && will_save_change_to_username? }
+  validates :username, format: { with: USERNAME_ONLY_RE }, length: { maximum: USERNAME_LENGTH_HARD_LIMIT }, if: -> { (remote? || actor_type_application?) && will_save_change_to_username? }
 
   # Remote user validations
   validates :uri, presence: true, unless: :local?, on: :create

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -26,6 +26,8 @@ class CustomEmoji < ApplicationRecord
 
   LIMIT = 256.kilobytes
   MINIMUM_SHORTCODE_SIZE = 2
+  MAX_SHORTCODE_SIZE = 128
+  MAX_FEDERATED_SHORTCODE_SIZE = 2048
 
   SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
 
@@ -45,7 +47,8 @@ class CustomEmoji < ApplicationRecord
   normalizes :domain, with: ->(domain) { domain.downcase.strip }
 
   validates_attachment :image, content_type: { content_type: IMAGE_MIME_TYPES }, presence: true, size: { less_than: LIMIT }
-  validates :shortcode, uniqueness: { scope: :domain }, format: { with: SHORTCODE_ONLY_RE }, length: { minimum: MINIMUM_SHORTCODE_SIZE }
+  validates :shortcode, uniqueness: { scope: :domain }, format: { with: SHORTCODE_ONLY_RE }, length: { minimum: MINIMUM_SHORTCODE_SIZE, maximum: MAX_FEDERATED_SHORTCODE_SIZE }
+  validates :shortcode, length: { maximum: MAX_SHORTCODE_SIZE }, if: :local?
 
   scope :local, -> { where(domain: nil) }
   scope :remote, -> { where.not(domain: nil) }

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -30,6 +30,8 @@ class CustomFilter < ApplicationRecord
 
   EXPIRATION_DURATIONS = [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].freeze
 
+  TITLE_LENGTH_LIMIT = 256
+
   include Expireable
   include Redisable
 
@@ -41,6 +43,7 @@ class CustomFilter < ApplicationRecord
   accepts_nested_attributes_for :keywords, reject_if: :all_blank, allow_destroy: true
 
   validates :title, :context, presence: true
+  validates :title, length: { maximum: TITLE_LENGTH_LIMIT }
   validate :context_must_be_valid
 
   normalizes :context, with: ->(context) { context.map(&:strip).filter_map(&:presence) }

--- a/app/models/custom_filter_keyword.rb
+++ b/app/models/custom_filter_keyword.rb
@@ -17,7 +17,9 @@ class CustomFilterKeyword < ApplicationRecord
 
   belongs_to :custom_filter
 
-  validates :keyword, presence: true
+  KEYWORD_LENGTH_LIMIT = 512
+
+  validates :keyword, presence: true, length: { maximum: KEYWORD_LENGTH_LIMIT }
 
   alias_attribute :phrase, :keyword
 

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -17,6 +17,7 @@ class List < ApplicationRecord
   include Paginable
 
   PER_ACCOUNT_LIMIT = 50
+  TITLE_LENGTH_LIMIT = 256
 
   enum :replies_policy, { list: 0, followed: 1, none: 2 }, prefix: :show, validate: true
 
@@ -26,7 +27,7 @@ class List < ApplicationRecord
   has_many :accounts, through: :list_accounts
   has_many :active_accounts, -> { merge(ListAccount.active) }, through: :list_accounts, source: :account
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: TITLE_LENGTH_LIMIT }
 
   validate :validate_account_lists_limit, on: :create
 

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -51,9 +51,9 @@ class Quote < ApplicationRecord
 
   def reject!
     if accepted?
-      update!(state: :revoked)
+      update!(state: :revoked, approval_uri: nil)
     elsif !revoked?
-      update!(state: :rejected)
+      update!(state: :rejected, approval_uri: nil)
     end
   end
 

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -48,7 +48,7 @@ class Quote < ApplicationRecord
   def accept!
     update!(state: :accepted)
 
-    reset_parent_cache! if attribute_changed?(:state)
+    reset_parent_cache! if attribute_previously_changed?(:state)
   end
 
   def reject!

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -47,6 +47,8 @@ class Quote < ApplicationRecord
 
   def accept!
     update!(state: :accepted)
+
+    reset_parent_cache! if attribute_changed?(:state)
   end
 
   def reject!
@@ -74,6 +76,15 @@ class Quote < ApplicationRecord
   end
 
   private
+
+  def reset_parent_cache!
+    return if status_id.nil?
+
+    Rails.cache.delete("v3:statuses/#{status_id}")
+
+    # This clears the web cache for the ActivityPub representation
+    Rails.cache.delete("statuses/show:v3:statuses/#{status_id}")
+  end
 
   def set_accounts
     self.account = status.account

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -92,7 +92,6 @@ class ActivityPub::FetchRemoteStatusService < BaseService
       existing_status = Status.remote.find_by(uri: uri)
       if existing_status&.distributable?
         Rails.logger.debug { "FetchRemoteStatusService - Got 404 for orphaned status with URI #{uri}, deleting" }
-        Tombstone.find_or_create_by(uri: uri, account: existing_status.account)
         RemoveStatusService.new.call(existing_status, redraft: false)
       end
     end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -204,7 +204,11 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
   def update_tags!
     previous_tags = @status.tags.to_a
-    current_tags = @status.tags = Tag.find_or_create_by_names(@raw_tags)
+    current_tags = @status.tags = @raw_tags.flat_map do |tag|
+      Tag.find_or_create_by_names([tag]).filter(&:valid?)
+    rescue ActiveRecord::RecordInvalid
+      []
+    end
 
     return unless @status.distributable?
 

--- a/app/services/app_sign_up_service.rb
+++ b/app/services/app_sign_up_service.rb
@@ -3,12 +3,12 @@
 class AppSignUpService < BaseService
   include RegistrationHelper
 
-  def call(app, remote_ip, params)
+  def call(app, remote_ip, params, trusted: false)
     @app       = app
     @remote_ip = remote_ip
     @params    = params
 
-    raise Mastodon::NotPermittedError unless allowed_registration?(remote_ip, invite)
+    raise Mastodon::NotPermittedError unless trusted || allowed_registration?(remote_ip, invite)
 
     ApplicationRecord.transaction do
       create_user!

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -31,7 +31,7 @@ class BatchedRemoveStatusService < BaseService
     # transaction lock the database, but we use the delete method instead
     # of destroy to avoid all callbacks. We rely on foreign keys to
     # cascade the delete faster without loading the associations.
-    statuses_and_reblogs.each_slice(50) { |slice| Status.where(id: slice.map(&:id)).delete_all }
+    statuses_and_reblogs.each_slice(50) { |slice| Status.unscoped.where(id: slice.pluck(:id)).delete_all }
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -14,6 +14,8 @@ class FanOutOnWriteService < BaseService
     @account   = status.account
     @options   = options
 
+    return if @status.proper.account.suspended?
+
     check_race_condition!
     warm_payload_cache!
 

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -53,7 +53,7 @@ class FeedInsertWorker
 
   def notify?(filter_result)
     return false if @type != :home || @status.reblog? || (@status.reply? && @status.in_reply_to_account_id != @status.account_id) ||
-                    filter_result == :filter
+                    update? || filter_result == :filter
 
     Follow.find_by(account: @follower, target_account: @status.account)&.notify?
   end

--- a/bin/docker-haml-lint
+++ b/bin/docker-haml-lint
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Runs haml-lint inside the dev container for consistent Ruby tooling.
+# Used by lint-staged to avoid local Ruby/bundler version mismatches.
+#
+# Usage: bin/docker-haml-lint [haml-lint args...]
+
+set -euo pipefail
+
+IMAGE_NAME="theconnector-dev"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Build the dev image if it doesn't exist
+if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+  echo "Building dev container ($IMAGE_NAME)..." >&2
+  docker build -f "$SCRIPT_DIR/Dockerfile.dev" -t "$IMAGE_NAME" "$SCRIPT_DIR" >&2
+fi
+
+exec docker run --rm \
+  -v "$SCRIPT_DIR:/app" \
+  -w /app \
+  "$IMAGE_NAME" \
+  haml-lint "$@"

--- a/bin/docker-rubocop
+++ b/bin/docker-rubocop
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Runs rubocop inside the dev container for consistent Ruby tooling.
+# Used by lint-staged to avoid local Ruby/bundler version mismatches.
+#
+# Usage: bin/docker-rubocop [rubocop args...]
+# Example: bin/docker-rubocop --force-exclusion -a app/controllers/foo.rb
+
+set -euo pipefail
+
+IMAGE_NAME="theconnector-dev"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Build the dev image if it doesn't exist
+if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+  echo "Building dev container ($IMAGE_NAME)..." >&2
+  docker build -f "$SCRIPT_DIR/Dockerfile.dev" -t "$IMAGE_NAME" "$SCRIPT_DIR" >&2
+fi
+
+exec docker run --rm \
+  -v "$SCRIPT_DIR:/app" \
+  -w /app \
+  "$IMAGE_NAME" \
+  rubocop --config /app/.rubocop.yml "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.5.5
+    image: ghcr.io/mastodon/mastodon:v4.5.6
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -83,7 +83,7 @@ services:
     # build:
     #   dockerfile: ./streaming/Dockerfile
     #   context: .
-    image: ghcr.io/mastodon/mastodon-streaming:v4.5.5
+    image: ghcr.io/mastodon/mastodon-streaming:v4.5.6
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -102,7 +102,7 @@ services:
   sidekiq:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.5.5
+    image: ghcr.io/mastodon/mastodon:v4.5.6
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.5.4
+    image: ghcr.io/mastodon/mastodon:v4.5.5
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -83,7 +83,7 @@ services:
     # build:
     #   dockerfile: ./streaming/Dockerfile
     #   context: .
-    image: ghcr.io/mastodon/mastodon-streaming:v4.5.4
+    image: ghcr.io/mastodon/mastodon-streaming:v4.5.5
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -102,7 +102,7 @@ services:
   sidekiq:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.5.4
+    image: ghcr.io/mastodon/mastodon:v4.5.5
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      5
+      6
     end
 
     def default_prerelease

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      4
+      5
     end
 
     def default_prerelease

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,11 +13,11 @@ module Mastodon
     end
 
     def patch
-      '6.0.5-theatlsocial'
+      6
     end
 
     def default_prerelease
-      ''
+      'theatlsocial'
     end
 
     def prerelease

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,9 +1,9 @@
 const config = {
   '*': 'prettier --ignore-unknown --write',
-  'Gemfile|*.{rb,ruby,ru,rake}': 'bin/rubocop --force-exclusion -a',
+  'Gemfile|*.{rb,ruby,ru,rake}': 'bin/docker-rubocop --force-exclusion -a',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
   '*.{css,scss}': 'stylelint --fix',
-  '*.haml': 'bin/haml-lint -a',
+  '*.haml': 'bin/docker-haml-lint -a',
   '**/*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
 };
 

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -612,14 +612,6 @@ RSpec.describe ActivityPub::TagManager do
     end
   end
 
-  describe '#uri_to_local_id' do
-    let(:account) { Fabricate(:account, id_scheme: :username_ap_id) }
-
-    it 'returns the local ID' do
-      expect(subject.uri_to_local_id(subject.uri_for(account), :username)).to eq account.username
-    end
-  end
-
   describe '#uris_to_local_accounts' do
     it 'returns the expected local accounts' do
       account = Fabricate(:account)

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -128,6 +128,28 @@ RSpec.describe ActivityPub::TagManager do
             .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}")
         end
       end
+
+      context 'with a reblog' do
+        let(:status) { Fabricate(:status, account:, reblog: Fabricate(:status)) }
+
+        context 'when using a numeric ID based scheme' do
+          let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+          it 'returns a string starting with web domain and with the expected path' do
+            expect(subject.uri_for(status))
+              .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}/activity")
+          end
+        end
+
+        context 'when using the legacy username based scheme' do
+          let(:account) { Fabricate(:account, id_scheme: :username_ap_id) }
+
+          it 'returns a string starting with web domain and with the expected path' do
+            expect(subject.uri_for(status))
+              .to eq("#{host_prefix}/users/#{status.account.username}/statuses/#{status.id}/activity")
+          end
+        end
+      end
     end
 
     context 'with a remote status' do

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -183,6 +183,69 @@ RSpec.describe '/api/v1/accounts' do
           .to start_with('application/json')
       end
     end
+
+    context 'when API registrations are disabled' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('DISABLE_API_REGISTRATIONS').and_return('true')
+        allow(ENV).to receive(:[]).with('TRUSTED_REGISTRATION_CLIENT_IDS').and_return(nil)
+        allow(ENV).to receive(:[]).with('WEB_SIGNUP_URL').and_return(nil)
+      end
+
+      let(:agreement) { 'true' }
+
+      it 'returns 403 for untrusted app' do
+        subject
+
+        expect(response).to have_http_status(403)
+        expect(response.parsed_body).to include(error: 'API registrations are disabled')
+      end
+
+      context 'when app is in trusted list' do
+        before do
+          allow(ENV).to receive(:[]).with('TRUSTED_REGISTRATION_CLIENT_IDS').and_return(client_app.uid)
+        end
+
+        it 'creates a user successfully' do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(response.parsed_body[:access_token]).to_not be_blank
+        end
+      end
+
+      context 'when app is in comma-separated trusted list' do
+        before do
+          allow(ENV).to receive(:[]).with('TRUSTED_REGISTRATION_CLIENT_IDS').and_return("other-id, #{client_app.uid}, another-id")
+        end
+
+        it 'creates a user successfully' do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(response.parsed_body[:access_token]).to_not be_blank
+        end
+      end
+    end
+
+    context 'when registrations are closed but app is trusted' do
+      before do
+        Setting.registrations_mode = 'none'
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('DISABLE_API_REGISTRATIONS').and_return('true')
+        allow(ENV).to receive(:[]).with('TRUSTED_REGISTRATION_CLIENT_IDS').and_return(client_app.uid)
+        allow(ENV).to receive(:[]).with('WEB_SIGNUP_URL').and_return(nil)
+      end
+
+      let(:agreement) { 'true' }
+
+      it 'creates a user even with registrations_mode none' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body[:access_token]).to_not be_blank
+      end
+    end
   end
 
   describe 'POST /api/v1/accounts/:id/follow' do

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -508,6 +508,15 @@ RSpec.describe '/api/v1/statuses' do
             .to start_with('application/json')
         end
       end
+
+      context 'when status has non-default quote policy and param is omitted' do
+        let(:status) { Fabricate(:status, account: user.account, quote_approval_policy: 'nobody') }
+
+        it 'preserves existing quote approval policy' do
+          expect { subject }
+            .to_not(change { status.reload.quote_approval_policy })
+        end
+      end
     end
   end
 

--- a/spec/requests/api/web/push_subscriptions_spec.rb
+++ b/spec/requests/api/web/push_subscriptions_spec.rb
@@ -163,9 +163,10 @@ RSpec.describe 'API Web Push Subscriptions' do
   end
 
   describe 'PUT /api/web/push_subscriptions/:id' do
-    before { sign_in Fabricate :user }
+    before { sign_in user }
 
-    let(:subscription) { Fabricate :web_push_subscription }
+    let(:user) { Fabricate(:user) }
+    let(:subscription) { Fabricate(:web_push_subscription, user: user) }
 
     it 'gracefully handles invalid nested params' do
       put api_web_push_subscription_path(subscription), params: { data: 'invalid' }

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -258,6 +258,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
           tag: [
             { type: 'Hashtag', name: 'foo' },
             { type: 'Hashtag', name: 'bar' },
+            { type: 'Hashtag', name: '#2024' },
           ],
         }
       end


### PR DESCRIPTION
## Summary
- **Merge upstream Mastodon v4.5.6** (31 commits: bugfixes for quotes, connection pooling, cache invalidation, etc.)
- **Fix member-site registration**: Add `TRUSTED_REGISTRATION_CLIENT_IDS` env var so the member-site OAuth app can bypass the `DISABLE_API_REGISTRATIONS` block
- **Containerized Ruby tooling**: Add `Dockerfile.dev` + wrapper scripts (`bin/docker-rubocop`, `bin/docker-haml-lint`) so lint-staged works on dev machines with mismatched Ruby/bundler versions
- **Fix version string**: Correct `version.rb` to produce `4.5.6-theatlsocial` (was incorrectly producing `4.5.6.0.5-theatlsocial`)

## Registration fix details
The fork's `DISABLE_API_REGISTRATIONS=true` env var was blocking ALL API registrations, including the member-site's legitimate OAuth client credentials flow at `join.theatl.social`. The new `trusted_registration_app?` method checks `TRUSTED_REGISTRATION_CLIENT_IDS` and allows listed OAuth apps to bypass both the API block and the `registrations_mode` check.

**Production env vars needed:**
```
TRUSTED_REGISTRATION_CLIENT_IDS=<member-site-oauth-client-id>
```

## Test plan
- [ ] CI passes (Ruby tests, JS tests, lint)
- [ ] Version string is `4.5.6-theatlsocial`
- [ ] Deploy with `TRUSTED_REGISTRATION_CLIENT_IDS` set to member-site client ID
- [ ] Test member-site signup creates account successfully
- [ ] Test random API client still gets 403 "API registrations are disabled"
- [ ] `bin/docker-rubocop` and `bin/docker-haml-lint` work locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)