### PR TITLE
Return confirmation token to trusted apps, suppress Devise email

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -33,12 +33,16 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def create
-    token    = AppSignUpService.new.call(doorkeeper_token.application, request.remote_ip, account_params, trusted: trusted_registration_app?)
+    service  = AppSignUpService.new
+    token    = service.call(doorkeeper_token.application, request.remote_ip, account_params, trusted: trusted_registration_app?)
     response = Doorkeeper::OAuth::TokenResponse.new(token)
 
     headers.merge!(response.headers)
 
-    self.response_body = Oj.dump(response.body)
+    body = response.body
+    body = body.merge(confirmation_token: service.user.confirmation_token) if trusted_registration_app? && service.user&.confirmation_token.present?
+
+    self.response_body = Oj.dump(body)
     self.status        = response.status
   rescue ActiveRecord::RecordInvalid => e
     render json: ValidationErrorFormatter.new(e, 'account.username': :username, 'invite_request.text': :reason).as_json, status: 422

--- a/app/services/app_sign_up_service.rb
+++ b/app/services/app_sign_up_service.rb
@@ -3,10 +3,13 @@
 class AppSignUpService < BaseService
   include RegistrationHelper
 
+  attr_reader :user
+
   def call(app, remote_ip, params, trusted: false)
     @app       = app
     @remote_ip = remote_ip
     @params    = params
+    @trusted   = trusted
 
     raise Mastodon::NotPermittedError unless trusted || allowed_registration?(remote_ip, invite)
 
@@ -21,9 +24,11 @@ class AppSignUpService < BaseService
   private
 
   def create_user!
-    @user = User.create!(
+    @user = User.new(
       user_params.merge(created_by_application: @app, sign_up_ip: @remote_ip, password_confirmation: user_params[:password], account_attributes: account_params, invite_request_attributes: invite_request_params)
     )
+    @user.skip_confirmation_notification! if @trusted
+    @user.save!
   end
 
   def create_access_token!

--- a/bin/docker-haml-lint
+++ b/bin/docker-haml-lint
@@ -15,8 +15,16 @@ if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
   docker build -f "$SCRIPT_DIR/Dockerfile.dev" -t "$IMAGE_NAME" "$SCRIPT_DIR" >&2
 fi
 
+# Convert absolute host paths to container-relative paths.
+# lint-staged passes absolute paths (e.g. /Users/.../app/views/foo.haml)
+# but inside the container the project is mounted at /app.
+args=()
+for arg in "$@"; do
+  args+=("${arg#"$SCRIPT_DIR/"}")
+done
+
 exec docker run --rm \
   -v "$SCRIPT_DIR:/app" \
   -w /app \
   "$IMAGE_NAME" \
-  haml-lint "$@"
+  haml-lint "${args[@]}"

--- a/bin/docker-rubocop
+++ b/bin/docker-rubocop
@@ -16,8 +16,16 @@ if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
   docker build -f "$SCRIPT_DIR/Dockerfile.dev" -t "$IMAGE_NAME" "$SCRIPT_DIR" >&2
 fi
 
+# Convert absolute host paths to container-relative paths.
+# lint-staged passes absolute paths (e.g. /Users/.../app/controllers/foo.rb)
+# but inside the container the project is mounted at /app.
+args=()
+for arg in "$@"; do
+  args+=("${arg#"$SCRIPT_DIR/"}")
+done
+
 exec docker run --rm \
   -v "$SCRIPT_DIR:/app" \
   -w /app \
   "$IMAGE_NAME" \
-  rubocop --config /app/.rubocop.yml "$@"
+  rubocop --config /app/.rubocop.yml "${args[@]}"

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -246,6 +246,52 @@ RSpec.describe '/api/v1/accounts' do
         expect(response.parsed_body[:access_token]).to_not be_blank
       end
     end
+
+    context 'when trusted app creates account (confirmation token)' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('DISABLE_API_REGISTRATIONS').and_return('true')
+        allow(ENV).to receive(:[]).with('TRUSTED_REGISTRATION_CLIENT_IDS').and_return(client_app.uid)
+        allow(ENV).to receive(:[]).with('WEB_SIGNUP_URL').and_return(nil)
+      end
+
+      let(:agreement) { 'true' }
+
+      it 'includes confirmation_token in the response' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body[:confirmation_token]).to be_present
+      end
+
+      it 'returns a token that matches the created user' do
+        subject
+
+        user = User.find_by(email: 'hello@world.tld')
+        expect(user).to_not be_nil
+        expect(user.confirmed?).to be false
+        expect(user.confirmation_token).to eq(response.parsed_body[:confirmation_token])
+      end
+
+      it 'does not send a confirmation email' do
+        ActiveJob::Base.queue_adapter = :test
+
+        expect { subject }
+          .to_not have_enqueued_job(ActionMailer::MailDeliveryJob)
+          .with('UserMailer', 'confirmation_instructions', anything, anything)
+      end
+    end
+
+    context 'when non-trusted app creates account (confirmation token)' do
+      let(:agreement) { 'true' }
+
+      it 'does not include confirmation_token in the response' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to_not have_key(:confirmation_token)
+      end
+    end
   end
 
   describe 'POST /api/v1/accounts/:id/follow' do

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -116,5 +116,36 @@ RSpec.describe AppSignUpService do
         expect(user.invite_request&.text).to eq 'Foo bar'
       end
     end
+
+    context 'when trusted: true' do
+      it 'exposes the created user via #user' do
+        subject.call(app, remote_ip, good_params, trusted: true)
+        expect(subject.user).to be_a(User)
+        expect(subject.user.email).to eq 'good@email.com'
+      end
+
+      it 'creates an unconfirmed user with a confirmation token' do
+        subject.call(app, remote_ip, good_params, trusted: true)
+        expect(subject.user.confirmed?).to be false
+        expect(subject.user.confirmation_token).to be_present
+      end
+
+      it 'suppresses the confirmation email' do
+        expect { subject.call(app, remote_ip, good_params, trusted: true) }
+          .to_not have_enqueued_job(ActionMailer::MailDeliveryJob)
+          .with('UserMailer', 'confirmation_instructions', anything, anything)
+      end
+    end
+
+    context 'when trusted: false' do
+      it 'does not expose user via #user before call' do
+        expect(subject.user).to be_nil
+      end
+
+      it 'sends the confirmation email' do
+        expect { subject.call(app, remote_ip, good_params, trusted: false) }
+          .to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end
+    end
   end
 end

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -131,6 +131,8 @@ RSpec.describe AppSignUpService do
       end
 
       it 'suppresses the confirmation email' do
+        ActiveJob::Base.queue_adapter = :test
+
         expect { subject.call(app, remote_ip, good_params, trusted: true) }
           .to_not have_enqueued_job(ActionMailer::MailDeliveryJob)
           .with('UserMailer', 'confirmation_instructions', anything, anything)
@@ -143,6 +145,8 @@ RSpec.describe AppSignUpService do
       end
 
       it 'sends the confirmation email' do
+        ActiveJob::Base.queue_adapter = :test
+
         expect { subject.call(app, remote_ip, good_params, trusted: false) }
           .to have_enqueued_job(ActionMailer::MailDeliveryJob)
       end

--- a/spec/system/auth/passwords_spec.rb
+++ b/spec/system/auth/passwords_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe 'Auth Passwords' do
     def submit_email_reset
       fill_in 'user_email', with: user.email
       click_on I18n.t('auth.reset_password')
+      expect(page).to have_title(I18n.t('auth.login'))
       open_last_email
       visit_in_email(I18n.t('devise.mailer.reset_password_instructions.action'))
     end

--- a/spec/system/auth/passwords_spec.rb
+++ b/spec/system/auth/passwords_spec.rb
@@ -49,9 +49,12 @@ RSpec.describe 'Auth Passwords' do
     end
 
     def submit_email_reset
-      fill_in 'user_email', with: user.email
-      click_on I18n.t('auth.reset_password')
-      expect(page).to have_title(I18n.t('auth.login'))
+      capture_emails do
+        fill_in 'user_email', with: user.email
+        click_on I18n.t('auth.reset_password')
+        expect(page).to have_title(I18n.t('auth.login'))
+      end
+
       open_last_email
       visit_in_email(I18n.t('devise.mailer.reset_password_instructions.action'))
     end


### PR DESCRIPTION
## Summary

- When a trusted OAuth app (via `TRUSTED_REGISTRATION_CLIENT_IDS`) creates an account through `POST /api/v1/accounts`, the response now includes `confirmation_token`
- Devise's confirmation email is suppressed for trusted apps via `skip_confirmation_notification!`, allowing the calling app (member site) to send a single consolidated welcome + confirmation email
- Fixes `bin/docker-rubocop` and `bin/docker-haml-lint` to convert absolute host paths to container-relative paths (lint-staged compatibility fix)

## How it works

```
Member Site  --->  POST /api/v1/accounts  --->  Mastodon
             <---  { access_token, confirmation_token }  <---
```

The member site reads `confirmation_token` from the response, builds a confirmation URL (`/auth/confirmation?confirmation_token=TOKEN`), and embeds it in the SendGrid welcome email. Users receive one email instead of two.

## Changes

| File | Change |
|------|--------|
| `app/services/app_sign_up_service.rb` | Split `User.create!` into `User.new` + `skip_confirmation_notification!` + `save!` for trusted apps; expose user via `attr_reader` |
| `app/controllers/api/v1/accounts_controller.rb` | Inject `confirmation_token` into OAuth response for trusted apps |
| `spec/services/app_sign_up_service_spec.rb` | Tests for user accessor, token presence, and email suppression |
| `spec/requests/api/v1/accounts_spec.rb` | Controller tests for token in response and non-trusted app exclusion |
| `bin/docker-rubocop` | Fix absolute→relative path conversion for lint-staged |
| `bin/docker-haml-lint` | Fix absolute→relative path conversion for lint-staged |

## Security

- Token only returned to apps in `TRUSTED_REGISTRATION_CLIENT_IDS` — never to regular API consumers
- Transmitted over HTTPS (server-to-server between Mastodon and member site)
- Single-use, time-limited (expires per `config.confirm_within = 2.days`)

## Test plan

- [ ] CI `test-ruby` workflow passes (new specs in `accounts_spec.rb` and `app_sign_up_service_spec.rb` auto-discovered by `bin/flatware rspec`)
- [ ] Existing account creation specs still pass (no regression)
- [ ] Manual: sign up via member site → receive single email with confirmation link → click link → land on Mastodon login → account confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)